### PR TITLE
fix: fix leakage of raw variables in diff view + diff not rendering

### DIFF
--- a/components/DiffBox.vue
+++ b/components/DiffBox.vue
@@ -83,10 +83,7 @@ export default {
   },
   data() {
     return {
-      processedDiffContent: {
-        type: String,
-        default: ''
-      }
+      processedDiffContent: ''
     }
   },
   beforeMount() {

--- a/components/RevisionPanel.vue
+++ b/components/RevisionPanel.vue
@@ -43,7 +43,7 @@
       <div class="card-text w-100 pl-sm-0 mb-3">
         <template  v-if="item.diffHtml">
           <h5 class="w-100">{{$t('Label-DiffView')}}</h5>
-          <diff-box v-bind:diffContent="item.diffHtml" :wikiRevId="wikiRevId" :diffMetadata="item.diffMetadata"/>
+          <diff-box v-bind:diffContent="item.diffHtml" :wikiRevId="`${item.wiki}:${item.revId}`" :diffMetadata="item.diffMetadata"/>
         </template>
         <template v-else>
         <h5>{{$t(`Message-DiffNotAvailable`)}}


### PR DESCRIPTION
The problem seemed to be caused by the fact that I didn't realize that `RevisionPanelItem` didn't have a `wikiRevId` attribute and also because I seemed to have used a weird `props` like syntax to define the `data` function return values in `DiffBox.vue`. :facepalm:

fixes: #355